### PR TITLE
feat(deploy): add Dockerfile, .dockerignore and update README for AWS/ECR/ECS deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# Ignore Gradle cache and build artifacts
+.gradle/
+build/
+!build/libs/*.jar
+
+# Ignore IDE files
+*.iml
+.idea/
+.vscode/
+
+# Ignore OS files
+.DS_Store
+Thumbs.db
+
+# Ignore test resources
+src/test/
+
+# Ignore logs
+*.log
+
+# Ignore environment files
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM gradle:8.14.3-jdk17 AS build
+WORKDIR /app
+COPY . .
+RUN gradle clean build -x test --no-daemon
+
+FROM eclipse-temurin:17-jre-alpine
+WORKDIR /app
+
+COPY --from=build /app/build/libs/retoaws-0.0.1-SNAPSHOT.jar app.jar
+
+ENV DB_HOST=localhost \
+    DB_PORT=3306 \
+    DB_NAME=awsreto_person_db \
+    DB_USERNAME=root \
+    DB_PASSWORD=toor \
+    SERVER_PORT=8092
+
+EXPOSE 8092
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/README.md
+++ b/README.md
@@ -39,11 +39,9 @@ This microservice is built with Java 17 and Spring Boot 3.x, following hexagonal
 ```
 DB_HOST=localhost
 DB_PORT=3306
-DB_NAME=retoaws_person_db
+DB_NAME=awsreto_person_db
 DB_USERNAME=root
 DB_PASSWORD=toor
-JWT_SECRET=your-secret-key
-JWT_EXPIRATION=86400000
 SERVER_PORT=8092
 ```
 
@@ -52,6 +50,20 @@ SERVER_PORT=8092
 - Minimum 80% coverage on domain logic
 - Code and documentation in English
 - Conventional commits and branching
+
+## Deployment (AWS/ECR/ECS)
+
+### Docker
+- Multi-stage Dockerfile included (`Dockerfile`)
+- `.dockerignore` for optimized builds
+- Build image: `docker build -t awsreto-person-api .`
+
+> Note: Environment variables in Dockerfile are defaults; real values are set in ECS Task Definition.
+
+## References
+- Swagger UI: `/swagger-ui.html`
+- Dockerfile and .dockerignore in project root
+
 
 ---
 > For technical questions, refer to the Swagger documentation and the tests in `src/test/java/com/talentpool/retoaws/domain/usecases/PersonUseCaseTest.java`.


### PR DESCRIPTION
Summary:
- Added Dockerfile (multi-stage, Gradle 8.14.3, Spring Boot 3.x)
- Added .dockerignore for optimized builds
- Updated README.md with deployment instructions for AWS/ECR/ECS

Justification:
- Prepares the API for containerization and cloud deployment
- Documents the process for future maintainers

References:
- HU3: API deployment in AWS

Testing:
- Docker image built and tested locally
- Endpoints validated with local MySQL

Checklist:
- [x] Code reviewed
- [x] Tests passed
- [x] Documentation updated