### PR TITLE
chore(env): enable AWS Parameter Store and Secrets Manager integration for environment config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,10 @@ RUN gradle clean build -x test --no-daemon
 
 FROM eclipse-temurin:17-jre-alpine
 WORKDIR /app
-
 COPY --from=build /app/build/libs/retoaws-0.0.1-SNAPSHOT.jar app.jar
 
-ENV DB_HOST=localhost \
-    DB_PORT=3306 \
-    DB_NAME=awsreto_person_db \
-    DB_USERNAME=root \
-    DB_PASSWORD=toor \
-    SERVER_PORT=8092
+ENV SPRING_PROFILES_ACTIVE=prod
 
-EXPOSE 8092
+EXPOSE 8191
 
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,8 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'com.h2database:h2:2.2.224'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.awspring.cloud:spring-cloud-aws-starter-secrets-manager:3.0.3'
+	implementation 'io.awspring.cloud:spring-cloud-aws-starter-parameter-store:3.0.3'
 }
 
 jacoco {

--- a/build.gradle
+++ b/build.gradle
@@ -38,8 +38,6 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'com.h2database:h2:2.2.224'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'io.awspring.cloud:spring-cloud-aws-starter-secrets-manager:3.0.3'
-	implementation 'io.awspring.cloud:spring-cloud-aws-starter-parameter-store:3.0.3'
 }
 
 jacoco {

--- a/src/main/java/com/talentpool/retoaws/infrastructure/controllers/PersonController.java
+++ b/src/main/java/com/talentpool/retoaws/infrastructure/controllers/PersonController.java
@@ -19,7 +19,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/v1/person")
+@RequestMapping("/api/v1/person")
 @Tag(name = "Person API", description = "Operations related to Person")
 public class PersonController {
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -2,11 +2,21 @@ spring:
   config:
     activate:
       on-profile: prod
+    import:
+      - "aws-secretsmanager:retoaws/prod/database/credentials"
+      - "aws-parameterstore:"
+      
+  cloud:
+    aws:
+      credentials:
+        instance-profile: true
+      region:
+        static: us-east-1
       
   datasource:
-    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
+    url: jdbc:mysql://${/retoaws/prod/database/host}:${/retoaws/prod/database/port}/${/retoaws/prod/database/name}
+    username: ${username}
+    password: ${password}
     driver-class-name: com.mysql.cj.jdbc.Driver
     hikari:
       maximum-pool-size: 5
@@ -23,14 +33,17 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
-
   sql:
     init:
       mode: always
       schema-locations: classpath:schema-prod.sql
-        
+
+server:
+  port: ${/retoaws/prod/server/port}
+
 logging:
   level:
-    "[com.talentpool.retoaws]": INFO
+    "[com.talentpool.retoaws]": DEBUG
     "[org.hibernate.SQL]": WARN
-    "[org.springframework.web]": WARN
+    "[org.springframework.web]": DEBUG
+    "[org.apache.catalina]": DEBUG

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -2,21 +2,11 @@ spring:
   config:
     activate:
       on-profile: prod
-    import:
-      - "aws-secretsmanager:retoaws/prod/database/credentials"
-      - "aws-parameterstore:"
-      
-  cloud:
-    aws:
-      credentials:
-        instance-profile: true
-      region:
-        static: us-east-1
-      
+
   datasource:
-    url: jdbc:mysql://${/retoaws/prod/database/host}:${/retoaws/prod/database/port}/${/retoaws/prod/database/name}
-    username: ${username}
-    password: ${password}
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
     hikari:
       maximum-pool-size: 5
@@ -25,7 +15,7 @@ spring:
       idle-timeout: 300000
       max-lifetime: 1200000
       leak-detection-threshold: 60000
-      
+  
   jpa:
     hibernate:
       ddl-auto: validate
@@ -33,13 +23,14 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
+  
   sql:
     init:
       mode: always
       schema-locations: classpath:schema-prod.sql
 
 server:
-  port: ${/retoaws/prod/server/port}
+  port: ${SERVER_PORT}
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,8 +2,8 @@ spring:
   application:
     name: retoaws-person-api
   profiles:
-    active: ${/retoaws/prod/spring/profiles/active:dev}
-  
+    active: ${SPRING_PROFILES_ACTIVE:dev}
+
   jpa:
     properties:
       hibernate:
@@ -11,7 +11,7 @@ spring:
         "[show_sql]": false
 
 server:
-  port: ${/retoaws/prod/server/port:8191}
+  port: ${SERVER_PORT:8191}
 
 management:
   endpoints:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: retoaws-person-api
   profiles:
-    active: ${SPRING_PROFILES_ACTIVE:dev}
+    active: ${/retoaws/prod/spring/profiles/active:dev}
   
   jpa:
     properties:
@@ -11,9 +11,7 @@ spring:
         "[show_sql]": false
 
 server:
-  port: ${SERVER_PORT:8092}
-  servlet:
-    context-path: /api
+  port: ${/retoaws/prod/server/port:8191}
 
 management:
   endpoints:
@@ -23,7 +21,6 @@ management:
   endpoint:
     health:
       show-details: when-authorized
-
 logging:
   level:
     "[com.talentpool.retoaws]": INFO


### PR DESCRIPTION
## Summary of changes
- Refactored environment configuration to use classic environment variables for DB and server settings.
- Prepared the API for deployment in AWS using environment variables managed by Parameter Store and Secrets Manager (ARN referenced in Task Definition).
- Updated Dockerfile to expose port 8191 and set SPRING_PROFILES_ACTIVE=prod.
- Cleaned up dependencies and configuration for secure and flexible deployment in AWS.
- Minor refactor in routes and logging for clarity and traceability.

## Justification
Allows secure and centralized management of sensitive credentials and parameters in AWS, facilitating deployment and administration of production environments.

## References
- HU-5: Use environment variables in the system (Parameter Store and Secrets Manager)

## Testing instructions
- Verify the API starts correctly with environment variables defined.
- Validate database access and protected endpoints.
- Check logs to ensure correct configuration loading.

## Checklist
- [x] Code reviewed
- [x] Tests added/updated (if applicable)
- [x] Documentation updated (if applicable)
