### PR TITLE
feat(infrastructure): add 5XX error simulation endpoint and global handler for AWS alarm testing

### DIFF
--- a/src/main/java/com/talentpool/retoaws/infrastructure/controllers/PersonController.java
+++ b/src/main/java/com/talentpool/retoaws/infrastructure/controllers/PersonController.java
@@ -12,6 +12,8 @@ import org.springframework.web.bind.annotation.RestController;
 import com.talentpool.retoaws.application.dto.PersonRequestDTO;
 import com.talentpool.retoaws.application.dto.PersonResponseDTO;
 import com.talentpool.retoaws.application.handlers.PersonHandler;
+import com.talentpool.retoaws.infrastructure.exceptions.SimulatedInternalServerErrorException;
+import com.talentpool.retoaws.infrastructure.utils.InfrastructureConstants;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -38,5 +40,10 @@ public class PersonController {
         return new ResponseEntity<>(
                 personHandler.getPerson(identificationNumber),
                 HttpStatus.OK);
+    }
+
+    @GetMapping("/test-error")
+    public ResponseEntity<String> testError() {
+        throw new SimulatedInternalServerErrorException(InfrastructureConstants.SIMULATED_5XX_ERROR_MESSAGE);
     }
 }

--- a/src/main/java/com/talentpool/retoaws/infrastructure/exceptionhandler/ControllerAdvisor.java
+++ b/src/main/java/com/talentpool/retoaws/infrastructure/exceptionhandler/ControllerAdvisor.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import com.talentpool.retoaws.domain.exceptions.PersonAlreadyExistsException;
 import com.talentpool.retoaws.domain.exceptions.PersonNotFoundException;
 
+import com.talentpool.retoaws.infrastructure.exceptions.SimulatedInternalServerErrorException;
+
 @ControllerAdvice
 public class ControllerAdvisor {
 
@@ -24,6 +26,13 @@ public class ControllerAdvisor {
     public ResponseEntity<ExceptionResponse> handlePersonAlreadyExistsException(
             PersonAlreadyExistsException exception) {
         return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(new ExceptionResponse(exception.getMessage(), LocalDateTime.now()));
+    }
+
+    @ExceptionHandler(SimulatedInternalServerErrorException.class)
+    public ResponseEntity<ExceptionResponse> handleSimulatedInternalServerErrorException(
+            SimulatedInternalServerErrorException exception) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(new ExceptionResponse(exception.getMessage(), LocalDateTime.now()));
     }
 

--- a/src/main/java/com/talentpool/retoaws/infrastructure/exceptions/SimulatedInternalServerErrorException.java
+++ b/src/main/java/com/talentpool/retoaws/infrastructure/exceptions/SimulatedInternalServerErrorException.java
@@ -1,0 +1,7 @@
+package com.talentpool.retoaws.infrastructure.exceptions;
+
+public class SimulatedInternalServerErrorException extends RuntimeException {
+    public SimulatedInternalServerErrorException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/talentpool/retoaws/infrastructure/utils/InfrastructureConstants.java
+++ b/src/main/java/com/talentpool/retoaws/infrastructure/utils/InfrastructureConstants.java
@@ -1,0 +1,11 @@
+package com.talentpool.retoaws.infrastructure.utils;
+
+public final class InfrastructureConstants {
+
+    public static final String SIMULATED_5XX_ERROR_MESSAGE = "This is a test to generate a 5XX error.";
+
+    private InfrastructureConstants() {
+        throw new IllegalStateException("Utility class");
+    }
+
+}


### PR DESCRIPTION
Summary of changes:
- Added endpoint `/api/v1/person/test-error` to simulate 5XX errors for AWS CloudWatch/ALB alarm testing.
- Created `SimulatedInternalServerErrorException` and registered it in `ControllerAdvisor` for global error handling.
- Centralized error message in `InfrastructureConstants`.

Justification:
This implementation allows robust simulation and monitoring of 5XX errors, supporting AWS alarm validation and maintainable error handling.

References:
- HU6: Logs and Traces in the Main API

Testing Instructions:
- Call `GET /api/v1/person/test-error` and verify a 500 response with the expected error body.
- Validate CloudWatch/ALB alarm triggers on 5XX errors.

Checklist:
- [x] Code reviewed
- [x] Tests added/updated (if applicable)
- [x] Documentation updated
